### PR TITLE
Add GitHub Skills Activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": ["alex@mergington.edu", "ryan@mergington.edu"]
     }
 }
 


### PR DESCRIPTION
This PR adds the missing "GitHub Skills" activity to the school activities signup page, as requested in issue #6. The activity includes details about learning coding and collaboration skills through GitHub, with a schedule on Mondays and Wednesdays, and space for up to 25 participants.